### PR TITLE
Add macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ build/
 build.ninja
 .ninja_*
 /wibo
+
+# macOS Artifacts
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ This repository contains a reverse-engineered codebase for *The World Ends With 
 
 1. This project supports the following operating systems:
     - Windows (Recommended)
+    - macOS
     - Linux
 2. Install the following:
     - Python 3.11+ and pip
     - GCC 9+
     - Ninja
+    - Wine (macOS only)
 3. Install Python dependencies: `python -m pip install -r tools/requirements.txt`
 
 ## Setup Instructions

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -13,17 +13,23 @@ VERSIONS = [
 ]
 DEFAULT_VERSION = VERSIONS.index("usa")
 
-DEFAULT_WIBO_PATH = "./wibo"
+# Platform info
+platform = get_platform()
+if platform is None:
+    exit(1)
 
+DEFAULT_WINE_PATH = "./wibo"
+if platform.system == "macos":
+    DEFAULT_WINE_PATH = "wine"
 
 parser = argparse.ArgumentParser(description="Generates build.ninja")
 parser.add_argument(
     "-w",
     type=str,
-    default=DEFAULT_WIBO_PATH,
+    default=DEFAULT_WINE_PATH,
     dest="wine",
     required=False,
-    help="Path to Wine/Wibo (linux only)",
+    help="Path to Wine/Wibo (macOS/Linux only)",
 )
 parser.add_argument(
     "--compiler",
@@ -48,7 +54,7 @@ args = parser.parse_args()
 # Config
 GAME = "twewy"
 
-DSD_VERSION = "v0.8.0"
+DSD_VERSION = "0.8.0" 
 WIBO_VERSION = "0.6.16"
 OBJDIFF_VERSION = "v2.7.1"
 MWCC_VERSION = "2.0/sp1p5"
@@ -119,11 +125,6 @@ for root, dirs, _ in os.walk(libs_path):
             includes.append(Path(root) / dir)
 CC_INCLUDES = " ".join(f"-i {include}" for include in includes)
 
-
-# Platform info
-platform = get_platform()
-if platform is None:
-    exit(1)
 
 EXE = platform.exe
 WINE = args.wine if platform.system != "windows" else ""
@@ -352,7 +353,7 @@ def add_download_tool_builds(n: ninja_syntax.Writer):
         )
         n.newline()
 
-    if platform.system != "windows" and WINE == DEFAULT_WIBO_PATH:
+    if platform.system == "linux" and WINE == DEFAULT_WINE_PATH:
         n.build(
             rule="download_tool",
             outputs=WINE,
@@ -363,7 +364,6 @@ def add_download_tool_builds(n: ninja_syntax.Writer):
             },
         )
         n.newline()
-
 
 def add_extract_build(n: ninja_syntax.Writer, project: Project):
     if not args.no_extract:

--- a/tools/download_tool.py
+++ b/tools/download_tool.py
@@ -21,8 +21,12 @@ parser.add_argument("--path", type=Path, required=True)
 args = parser.parse_args()
 
 
+# Change back to AetiasHax/ds-decomp once repo is updated to latest ds-decomp and macOS supported has been added
+# REPO_URL = "https://github.com/AetiasHax/ds-decomp"
+REPO_URL = "https://github.com/emiyl/ds-decomp"
+
 def dsd_url(tag: str) -> str:
-    return f"https://github.com/AetiasHax/ds-decomp/releases/download/{tag}/dsd-{platform.system}-{platform.machine}{platform.exe}"
+    return f"{REPO_URL}/releases/download/{tag}/dsd-{platform.system}-{platform.machine}{platform.exe}"
 
 
 def mwccarm_url(tag: str) -> str:

--- a/tools/get_platform.py
+++ b/tools/get_platform.py
@@ -5,10 +5,10 @@ class Platform:
 
     def __init__(self, *, system: str, machine: str, exe: str):
         self.system = system
-        '''Name of operating system: "windows", "dawrin" or "linux"'''
+        '''Name of operating system: "windows", "macos" or "linux"'''
 
         self.machine = machine
-        '''Name of machine architecture: "x86_64" or "aarch64"'''
+        '''Name of machine architecture: "x86_64" or "arm64"'''
 
         self.exe = exe
         """Executable file extension: ".exe" for Windows, "" otherwise"""
@@ -34,8 +34,6 @@ def get_platform() -> Platform | None:
             machine = "x86_64"
         case "arm64":
             machine = "arm64"
-        case "aarch64":
-            machine = "aarch64"
         case machine:
             print(f"Unknown machine: {machine}")
             return None

--- a/tools/get_platform.py
+++ b/tools/get_platform.py
@@ -38,4 +38,16 @@ def get_platform() -> Platform | None:
             print(f"Unknown machine: {machine}")
             return None
 
+    supported_platforms = [
+        "windows-x86_64",
+        "linux-x86_64",
+        "macos-x86_64",
+        "macos-arm64"
+    ]
+
+    combined = f"{system}-{machine}"
+    if combined not in supported_platforms:
+        print(f"Unsupported platform: {combined}")
+        return None
+
     return Platform(system=system, machine=machine, exe=exe)

--- a/tools/get_platform.py
+++ b/tools/get_platform.py
@@ -5,10 +5,10 @@ class Platform:
 
     def __init__(self, *, system: str, machine: str, exe: str):
         self.system = system
-        '''Name of operating system: "windows" or "linux"'''
+        '''Name of operating system: "windows", "dawrin" or "linux"'''
 
         self.machine = machine
-        '''Name of machine architecture: "x86_64"'''
+        '''Name of machine architecture: "x86_64" or "aarch64"'''
 
         self.exe = exe
         """Executable file extension: ".exe" for Windows, "" otherwise"""
@@ -23,6 +23,8 @@ def get_platform() -> Platform | None:
         exe = ".exe"
     elif system == "Linux":
         system = "linux"
+    elif system == "Darwin":
+        system = "macos"
     else:
         print(f"Unknown system '{system}'")
         return None
@@ -30,6 +32,10 @@ def get_platform() -> Platform | None:
     match platform.machine().lower():
         case "amd64" | "x86_64":
             machine = "x86_64"
+        case "arm64":
+            machine = "arm64"
+        case "aarch64":
+            machine = "aarch64"
         case machine:
             print(f"Unknown machine: {machine}")
             return None


### PR DESCRIPTION
This allows for macOS x86_64 and ARM64 support, using builds of ds-decomp from https://github.com/emiyl/ds-decomp/releases/tag/0.8.0. This should be changed back to AetiasHax/ds-decomp once macOS support has been merged and this repo has been updated to latest ds-decomp.

While Linux uses the drop-in wibo executable to run exe files, no such equivalent exists for macOS users, so they will have to install wine via brew themselves. macOS binaries exist for other programs such as objdiff, so there is no issue there.

macOS users can use the -w command too, to change the wine path. I changed some of the variable labels from wibo to wine, for the following reasons, as wine is cross-platform and users are more likely to have a pre-existing wine installation than a wibo installation. It will still default to wibo on Linux, however.